### PR TITLE
fixed data clipping when appliance not in the house

### DIFF
--- a/src/helpers/preprocessing.py
+++ b/src/helpers/preprocessing.py
@@ -730,7 +730,14 @@ class UKDALE_DataBuilder(object):
                 else:
                     continue
             else:
+                # zero padding for missing appliance
+                # this is needed to clip the data when the appliance is not
+                # in the house
                 house_data[appliance] = 0
+                house_data = house_data.clip(
+                    lower=0, upper=self.cutoff
+                )  # Apply general cutoff
+                house_data = house_data.sort_index()
                 house_data[appliance + "_status"] = 0
 
         return house_data


### PR DESCRIPTION
## fixed data clipping when appliance not in the house
I noticed an issue in the preprocessing code, when clipping the values between the cutoff value, it is only done when the appliance data is read, but when the appliance data doesn't exist in the house, it is zero padded so, that part should also be processed.
I noticed this when working the ukdale dataset, house 4 doesn't have washing_machine as a stand alone data, so it values is shooting as high as 8,000W as it is not being cutoff.